### PR TITLE
Update BotConfig.java

### DIFF
--- a/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
+++ b/src/main/java/com/jagrosh/jmusicbot/BotConfig.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2018 John Grosh (jagrosh)
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License" );
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -43,14 +43,14 @@ public class BotConfig
     private String token, prefix, altprefix, helpWord, playlistsFolder,
             successEmoji, warningEmoji, errorEmoji, loadingEmoji, searchingEmoji;
     private boolean stayInChannel, songInGame, npImages, updatealerts, useEval, dbots;
-    private long owner, maxSeconds, aloneTimeUntilStop;
+    private long owner, maxSeconds, aloneTimeUntilStop, queueType;
     private OnlineStatus status;
     private Activity game;
     private Config aliases, transforms;
 
     private boolean valid = false;
     
-    public BotConfig(Prompt prompt)
+    public BotConfig( Prompt prompt )
     {
         this.prompt = prompt;
     }
@@ -63,11 +63,13 @@ public class BotConfig
         try 
         {
             // get the path to the config, default config.txt
-            path = OtherUtil.getPath(System.getProperty("config.file", System.getProperty("config", "config.txt")));
-            if(path.toFile().exists())
+            path = OtherUtil.getPath( System.getProperty( "config.file", System.getProperty( "config", "config.txt" ) ) );
+            if ( path.toFile().exists() )
             {
-                if(System.getProperty("config.file") == null)
-                    System.setProperty("config.file", System.getProperty("config", path.toAbsolutePath().toString()));
+                if ( System.getProperty( "config.file" ) == null )
+                {
+                    System.setProperty( "config.file", System.getProperty( "config", path.toAbsolutePath().toString() ) );
+                }
                 ConfigFactory.invalidateCaches();
             }
             
@@ -76,69 +78,69 @@ public class BotConfig
             Config config = ConfigFactory.load();
             
             // set values
-            token = config.getString("token");
-            prefix = config.getString("prefix");
-            altprefix = config.getString("altprefix");
-            helpWord = config.getString("help");
-            owner = config.getLong("owner");
-            successEmoji = config.getString("success");
-            warningEmoji = config.getString("warning");
-            errorEmoji = config.getString("error");
-            loadingEmoji = config.getString("loading");
-            searchingEmoji = config.getString("searching");
-            game = OtherUtil.parseGame(config.getString("game"));
-            status = OtherUtil.parseStatus(config.getString("status"));
-            stayInChannel = config.getBoolean("stayinchannel");
-            songInGame = config.getBoolean("songinstatus");
-            npImages = config.getBoolean("npimages");
-            updatealerts = config.getBoolean("updatealerts");
-            useEval = config.getBoolean("eval");
-            maxSeconds = config.getLong("maxtime");
-            aloneTimeUntilStop = config.getLong("alonetimeuntilstop");
-            playlistsFolder = config.getString("playlistsfolder");
-            aliases = config.getConfig("aliases");
-            transforms = config.getConfig("transforms");
+            token              = config.getString( "token"  );
+            prefix             = config.getString( "prefix" );
+            altprefix          = config.getString( "altprefix" );
+            helpWord           = config.getString( "help"    );
+            owner              = config.getLong( "owner"     );
+            successEmoji       = config.getString( "success" );
+            warningEmoji       = config.getString( "warning" );
+            errorEmoji         = config.getString( "error"   );
+            loadingEmoji       = config.getString( "loading" );
+            searchingEmoji     = config.getString( "searching" );
+            game               = OtherUtil.parseGame(   config.getString( "game"   ) );
+            status             = OtherUtil.parseStatus( config.getString( "status" ) );
+            stayInChannel      = config.getBoolean( "stayinchannel" );
+            songInGame         = config.getBoolean( "songinstatus"  );
+            npImages           = config.getBoolean( "npimages"      );
+            updatealerts       = config.getBoolean( "updatealerts"  );
+            useEval            = config.getBoolean( "eval" );
+            maxSeconds         = config.getLong( "maxtime" );
+            aloneTimeUntilStop = config.getLong( "alonetimeuntilstop" );
+            playlistsFolder    = config.getString( "playlistsfolder" );  
+            aliases            = config.getConfig( "aliases" );
+            transforms         = config.getConfig( "transforms" );
+            queueType          = config.getLong( "queuetype" );
             dbots = owner == 113156185389092864L;
             
             // we may need to write a new config file
             boolean write = false;
 
             // validate bot token
-            if(token==null || token.isEmpty() || token.equalsIgnoreCase("BOT_TOKEN_HERE"))
+            if ( token == null || token.isEmpty() || token.equalsIgnoreCase( "BOT_TOKEN_HERE" ) )
             {
-                token = prompt.prompt("Please provide a bot token."
+                token = prompt.prompt( "Please provide a bot token."
                         + "\nInstructions for obtaining a token can be found here:"
                         + "\nhttps://github.com/jagrosh/MusicBot/wiki/Getting-a-Bot-Token."
-                        + "\nBot Token: ");
-                if(token==null)
+                        + "\nBot Token: " );
+                if ( token == null )
                 {
-                    prompt.alert(Prompt.Level.WARNING, CONTEXT, "No token provided! Exiting.\n\nConfig Location: " + path.toAbsolutePath().toString());
+                    prompt.alert( Prompt.Level.WARNING, CONTEXT, "No token provided! Exiting.\n\nConfig Location: " + path.toAbsolutePath().toString() );
                     return;
-                }
-                else
-                {
+                } else {
                     write = true;
                 }
             }
             
             // validate bot owner
-            if(owner<=0)
+            if ( owner <= 0 )
             {
                 try
                 {
-                    owner = Long.parseLong(prompt.prompt("Owner ID was missing, or the provided owner ID is not valid."
+                    owner = Long.parseLong(prompt.prompt( "Owner ID was missing, or the provided owner ID is not valid."
                         + "\nPlease provide the User ID of the bot's owner."
                         + "\nInstructions for obtaining your User ID can be found here:"
                         + "\nhttps://github.com/jagrosh/MusicBot/wiki/Finding-Your-User-ID"
-                        + "\nOwner User ID: "));
+                        + "\nOwner User ID: " ));
                 }
                 catch(NumberFormatException | NullPointerException ex)
                 {
                     owner = 0;
                 }
-                if(owner<=0)
+                
+                if ( owner <= 0 )
                 {
-                    prompt.alert(Prompt.Level.ERROR, CONTEXT, "Invalid User ID! Exiting.\n\nConfig Location: " + path.toAbsolutePath().toString());
+                    prompt.alert( Prompt.Level.ERROR, CONTEXT, "Invalid User ID! Exiting.\n\nConfig Location: " + path.toAbsolutePath().toString());
                     return;
                 }
                 else
@@ -147,42 +149,53 @@ public class BotConfig
                 }
             }
             
-            if(write)
+            if ( write )
+            {
                 writeToFile();
+            }
             
             // if we get through the whole config, it's good to go
             valid = true;
         }
-        catch (ConfigException ex)
+        catch ( ConfigException ex )
         {
-            prompt.alert(Prompt.Level.ERROR, CONTEXT, ex + ": " + ex.getMessage() + "\n\nConfig Location: " + path.toAbsolutePath().toString());
+            prompt.alert( 
+                Prompt.Level.ERROR, 
+                CONTEXT, 
+                ex + ": " + ex.getMessage() + "\n\nConfig Location: " + path.toAbsolutePath().toString()
+            );
         }
     }
     
     private void writeToFile()
     {
-        String original = OtherUtil.loadResource(this, "/reference.conf");
+        String original = OtherUtil.loadResource( this, "/reference.conf" );
         byte[] bytes;
-        if(original==null)
+        
+        if ( original == null )
         {
-            bytes = ("token = "+token+"\r\nowner = "+owner).getBytes();
+            bytes = ( "token = " + token + "\r\nowner = " + owner ).getBytes();
         }
         else
         {
-            bytes = original.substring(original.indexOf(START_TOKEN)+START_TOKEN.length(), original.indexOf(END_TOKEN))
-                .replace("BOT_TOKEN_HERE", token)
-                .replace("0 // OWNER ID", Long.toString(owner))
+            bytes = original.substring( original.indexOf(START_TOKEN) + START_TOKEN.length(), original.indexOf(END_TOKEN))
+                .replace( "BOT_TOKEN_HERE", token)
+                .replace( "0 // OWNER ID", Long.toString(owner))
                 .trim().getBytes();
         }
         try 
         {
-            Files.write(path, bytes);
+            Files.write( path, bytes );
         }
-        catch(IOException ex) 
+        catch( IOException ex ) 
         {
-            prompt.alert(Prompt.Level.WARNING, CONTEXT, "Failed to write new config options to config.txt: "+ex
+            prompt.alert( 
+                Prompt.Level.WARNING, 
+                CONTEXT, 
+                "Failed to write new config options to config.txt: " + ex
                 + "\nPlease make sure that the files are not on your desktop or some other restricted area.\n\nConfig Location: " 
-                + path.toAbsolutePath().toString());
+                + path.toAbsolutePath().toString()
+            );
         }
     }
     
@@ -298,7 +311,7 @@ public class BotConfig
     
     public String getMaxTime()
     {
-        return FormatUtil.formatTime(maxSeconds * 1000);
+        return FormatUtil.formatTime( maxSeconds * 1000 );
     }
 
     public long getAloneTimeUntilStop()
@@ -306,21 +319,20 @@ public class BotConfig
         return aloneTimeUntilStop;
     }
     
-    public boolean isTooLong(AudioTrack track)
+    public boolean isTooLong( AudioTrack track )
     {
-        if(maxSeconds<=0)
+        if ( maxSeconds <= 0 )
+        {
             return false;
-        return Math.round(track.getDuration()/1000.0) > maxSeconds;
+        }
+        return Math.round( track.getDuration() / 1000.0 ) > maxSeconds;
     }
 
-    public String[] getAliases(String command)
+    public String[] getAliases( String command )
     {
-        try
-        {
-            return aliases.getStringList(command).toArray(new String[0]);
-        }
-        catch(NullPointerException | ConfigException.Missing e)
-        {
+        try {
+            return aliases.getStringList( command ).toArray( new String[0] );
+        } catch( NullPointerException | ConfigException.Missing e ) {
             return new String[0];
         }
     }
@@ -328,5 +340,14 @@ public class BotConfig
     public Config getTransforms()
     {
         return transforms;
+    }
+    
+    /**
+     * @author: Matt Lind (lind6@illinois.edu)
+     * @return: (long) returns type of queue used to store items. 
+     */
+    public Long getQueueType()
+    {
+        return queueType;
     }
 }


### PR DESCRIPTION
#581 Override fair queue from config file.

### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Implements ability to specify queue type from configs.txt file to override fair queue behavior with FIFO queue.

### Purpose
MusicBot employs a 'fair' queue, which means tracks submitted to the player are inserted into the queue in random positions.  This prevents a user from dominating the musicplayer by submitting large lists of tracks and forcing other users to endure the list until their tracks make it to the front of the queue.  Some users dislike the fair queue and would prefer a simpler FIFO queue such as during a listening party or DJ'd event where the tracks are submitted in blocks and preferred on a first come first serve basis.

### Relevant Issue(s)
This PR closes issue #581
